### PR TITLE
Changed package.json to include snippets in sql

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,10 @@
             {
                 "language": "vue",
                 "path": "./snippets/snippets.json"
+            },
+            {
+                "language": "sql",
+                "path": "./snippets/snippets.json"
             }
         ]
     },


### PR DESCRIPTION
Added support for using your ext in MSSQL since comment blocks are the same as CSS by adding this line to the package.json file:
```
            {
                "language": "sql",
                "path": "./snippets/snippets.json"
            }
```